### PR TITLE
Update jinja2 container export example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,7 @@ laceworkreports export vulnerabilities containers csv --file-path out.csv --filt
 ### Export jinja2 container vulnerabilities with filters, returns, and field_map
 
 ```bash
-laceworkreports export vulnerabilities containers jinja --file-path out.csv --filters="@examples/filters/critical_vulnerable_containers.json" --returns="@examples/returns/container_short.json" --field-map="@examples/field_map/containers_vulnerabilities.json" --template-path="@examples/jinja2/advanced_bootstrap.html.js"
+laceworkreports export vulnerabilities containers jinja --file-path out.csv --filters="@examples/filters/critical_vulnerable_containers.json" --returns="@examples/returns/container_short.json" --field-map="@examples/field_map/containers_vulnerabilities.json" --template-path="./examples/jinja2/html/advanced_bootstrap.html.j2"
 ```
 
 ## SDK

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,7 @@ laceworkreports export vulnerabilities containers csv --file-path out.csv --filt
 ### Export jinja2 container vulnerabilities with filters, returns, and field_map
 
 ```bash
-laceworkreports export vulnerabilities containers jinja --file-path out.csv --filters="@examples/filters/critical_vulnerable_containers.json" --returns="@examples/returns/container_short.json" --field-map="@examples/field_map/containers_vulnerabilities.json" --template-path="./examples/jinja2/html/advanced_bootstrap.html.j2"
+laceworkreports export vulnerabilities containers jinja --file-path out.html --filters="@examples/filters/critical_vulnerable_containers.json" --returns="@examples/returns/container_short.json" --field-map="@examples/field_map/containers_vulnerabilities.json" --template-path="./examples/jinja2/html/advanced_bootstrap.html.j2"
 ```
 
 ## SDK


### PR DESCRIPTION
Updating the jinja2 container export example so that it runs.

## Description

Was using this to start analyzing our vulnerabilities and saw that the documentation for the "Export jinja2 container vulnerabilities with filters, returns, and field_map" didn't run on my machine. Fixed it so it works if someone is working from the root of the repository, but, if the "@" semantic should be used here that probably should be changed in the code logic (while the documentation made it clear the @ wasn't needed, I didn't catch it until I was already deep in research the repo figuring out why the code didn't work).


## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/laceworkps/laceworkreports/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/laceworkps/laceworkreports/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
